### PR TITLE
Handle null and make json encodable

### DIFF
--- a/lib/models/transaction.dart
+++ b/lib/models/transaction.dart
@@ -99,7 +99,7 @@ class Transaction implements JsonEncodable {
       'cleared': cleared?.name,
       'approved': approved,
       'import_id': importId,
-      'subtransactions': subtractions.map((s) => s.toJson()),
+      'subtransactions': subtractions?.map((s) => s.toJson())?.toList(),
     };
   }
 }


### PR DESCRIPTION
I am hitting an error when calling `TransactionsApi.createTransaction()`. It looks like there are two things going on here:

**Error 1**
When `subtransactions` is null.
```
Unhandled exception:
NoSuchMethodError: The method 'map' was called on null.
Receiver: null
Tried calling: map<Map<String, dynamic>>(Closure: (Subtransaction) => Map<String, dynamic>)
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:54:5)
#1      Transaction.toJson (package:ynab/models/transaction.dart:102:39)
``` 
The `Transaction.toJson()` doesn't handle the `null` case for `subtransactions`.

**Error 2**
When `subtransactions` is not null.
```
Unhandled exception:
Converting object to an encodable object failed: Instance of 'Transaction'
#0      _JsonStringifier.writeObject (dart:convert/json.dart:688:7)
#1      _JsonStringStringifier.printOn (dart:convert/json.dart:877:17)
#2      _JsonStringStringifier.stringify (dart:convert/json.dart:862:5)
#3      JsonEncoder.convert (dart:convert/json.dart:262:30)
#4      JsonCodec.encode (dart:convert/json.dart:172:45)
#5      jsonEncode (dart:convert/json.dart:81:10)
```
`List.map()` returns an `Iterable` which is not handled correctly by `jsonEncode`.

This PR fixes the first error using null aware operators and the second by calling `Iterable.toList()`.