### PR TITLE
Add json Content-Type header

### DIFF
--- a/lib/api/base.dart
+++ b/lib/api/base.dart
@@ -73,7 +73,7 @@ abstract class BaseApi {
       res = await http.patch(
         uri.toString(),
         body: jsonEncode(body ?? {}),
-        headers: bodyHeaders,
+        headers: bodyPayloadHeaders,
       );
     }
 

--- a/lib/api/base.dart
+++ b/lib/api/base.dart
@@ -49,6 +49,11 @@ abstract class BaseApi {
       'Authorization': configuration.apiKey,
     };
 
+    final bodyPayloadHeaders = {
+      ...headers,
+      'Content-Type': 'application/json',
+    };
+
     print('[$method] ${uri.toString()}');
 
     http.Response res;
@@ -62,13 +67,13 @@ abstract class BaseApi {
       res = await http.post(
         uri.toString(),
         body: jsonEncode(body ?? {}),
-        headers: headers,
+        headers: bodyPayloadHeaders,
       );
     } else if (method == 'PATCH') {
       res = await http.patch(
         uri.toString(),
         body: jsonEncode(body ?? {}),
-        headers: headers,
+        headers: bodyHeaders,
       );
     }
 


### PR DESCRIPTION
It turns out the YNAB api give the flowing response when you call make a POST request with a valid body to `/budgets/{budget_id}/transactions/{transaction_id}` but don't set the `Content-Type` header to `application/json`:

```
{
    "error": {
        "id": "400",
        "name": "bad_request",
        "detail": "either 'transaction' object or 'transactions' array must be supplied"
    }
}
```

This PR sets this header correctly for POST and PATCH requests to avoid the error.